### PR TITLE
Potential fix for code scanning alert no. 3: Server-side request forgery

### DIFF
--- a/app/lib/event-parser.ts
+++ b/app/lib/event-parser.ts
@@ -15,8 +15,9 @@ export async function parseEventUrl(url: string): Promise<ParseResult> {
     const urlObj = new URL(url)
     const hostname = urlObj.hostname.toLowerCase()
 
-    // Check supported platforms
-    if (!hostname.includes("meetup.com") && !hostname.includes("eventbrite.com") && !hostname.includes("lu.ma")) {
+    // Strict allow-list validation for supported platforms
+    const allowedHostnames = ["meetup.com", "eventbrite.com", "lu.ma"]
+    if (!allowedHostnames.some(allowed => hostname === allowed || hostname.endsWith(`.${allowed}`))) {
       return {
         success: false,
         error: "Unsupported platform. Currently supports Meetup.com, Eventbrite.com, and Lu.ma",


### PR DESCRIPTION
Potential fix for [https://github.com/434media/next-434media/security/code-scanning/3](https://github.com/434media/next-434media/security/code-scanning/3)

To fix the SSRF vulnerability, we need to ensure that the `url` parameter is strictly validated and restricted to a predefined allow-list of trusted domains. This can be achieved by:
1. Parsing the `url` and extracting its hostname.
2. Comparing the extracted hostname against a strict allow-list of trusted domains (e.g., `meetup.com`, `eventbrite.com`, `lu.ma`).
3. Rejecting any URL that does not match the allow-list.

Additionally, we should ensure that the `fetch` call only uses URLs that have been validated against the allow-list. This prevents attackers from crafting malicious URLs that bypass the validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
