### PR TITLE
Potential fix for code scanning alert no. 18: DOM text reinterpreted as HTML

### DIFF
--- a/app/components/blog/RichTextEditor.tsx
+++ b/app/components/blog/RichTextEditor.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 
 import { useState, useRef, useEffect } from "react"
+import DOMPurify from "dompurify"
 import {
   Bold,
   Italic,
@@ -118,7 +119,7 @@ export default function RichTextEditor({ value, onChange, placeholder, className
           range.deleteContents()
 
           const div = document.createElement("div")
-          div.innerHTML = html
+          div.innerHTML = DOMPurify.sanitize(html)
           const fragment = document.createDocumentFragment()
 
           while (div.firstChild) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "remixicon": "^4.6.0",
     "sonner": "^2.0.3",
     "three": "^0.178.0",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
Potential fix for [https://github.com/434media/next-434media/security/code-scanning/18](https://github.com/434media/next-434media/security/code-scanning/18)

To fix the issue, we need to sanitize or escape the `html` string before inserting it into the DOM. This can be achieved by using a library like `DOMPurify` to sanitize the HTML string, ensuring that any malicious scripts are removed. Alternatively, we can escape the string to ensure it is treated as plain text rather than HTML. 

The best approach here is to sanitize the `html` string using `DOMPurify` before assigning it to `div.innerHTML`. This ensures that any potentially harmful content is removed while preserving valid HTML structure.

**Steps to fix:**
1. Install the `dompurify` library if it is not already installed.
2. Import `DOMPurify` into the file.
3. Use `DOMPurify.sanitize` to sanitize the `html` string before assigning it to `div.innerHTML` on line 121.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
