### PR TITLE
Potential fix for code scanning alert no. 17: DOM text reinterpreted as HTML

### DIFF
--- a/app/components/blog/ImageSelector.tsx
+++ b/app/components/blog/ImageSelector.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import type React from "react"
+import isValidUrl from "validator/lib/isURL"
 import { useState, useEffect, useCallback } from "react"
 import { Upload, ImageIcon, LinkIcon, X, Check, Search, Loader2, RefreshCw, AlertCircle, Edit2 } from "lucide-react"
 import Image from "next/image"
@@ -439,7 +440,14 @@ export default function ImageSelector({
                 <input
                   type="url"
                   value={urlInput}
-                  onChange={(e) => setUrlInput(e.target.value)}
+                  onChange={(e) => {
+                    const input = e.target.value;
+                    if (isValidUrl(input)) {
+                      setUrlInput(input);
+                    } else {
+                      setUrlInput(""); // Clear input if invalid
+                    }
+                  }}
                   placeholder="https://example.com/image.jpg"
                   className="flex-1 px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent text-sm"
                 />
@@ -457,7 +465,7 @@ export default function ImageSelector({
               <div className="mt-4">
                 <p className="text-sm font-medium text-gray-700 mb-2">Preview:</p>
                 <img
-                  src={urlInput || "/placeholder.svg"}
+                  src={isValidUrl(urlInput) ? urlInput : "/placeholder.svg"}
                   alt="URL preview"
                   className="w-full h-32 object-cover rounded-lg border border-gray-200"
                   onError={(e) => {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "remixicon": "^4.6.0",
     "sonner": "^2.0.3",
     "three": "^0.178.0",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+    "validator": "^13.15.15"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
Potential fix for [https://github.com/434media/next-434media/security/code-scanning/17](https://github.com/434media/next-434media/security/code-scanning/17)

To fix the issue, we need to sanitize the `urlInput` value before using it as the `src` attribute of the `<img>` tag. This can be achieved by validating the URL format and ensuring it is safe. A library like `validator` can be used to check if the input is a valid URL. If the input is invalid, we can either reject it or replace it with a safe fallback value.

The changes will involve:
1. Importing a URL validation function (e.g., from the `validator` library).
2. Adding a validation step before setting the `urlInput` state.
3. Ensuring that only sanitized and validated URLs are used in the `src` attribute of the `<img>` tag.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
