### PR TITLE
Potential fix for code scanning alert no. 13: Incomplete URL substring sanitization

### DIFF
--- a/app/lib/video-utils.ts
+++ b/app/lib/video-utils.ts
@@ -12,9 +12,19 @@ export interface VideoInfo {
 
 export function analyzeVideoUrl(url: string): VideoInfo {
   const cleanUrl = url.trim()
+  let hostname = "";
+  try {
+    hostname = new URL(cleanUrl).hostname.replace(/^www\./, "");
+  } catch (e) {
+    // If URL parsing fails, treat as unsupported
+    return {
+      type: "unsupported",
+      url: cleanUrl,
+    }
+  }
 
   // YouTube detection
-  if (cleanUrl.includes("youtube.com") || cleanUrl.includes("youtu.be")) {
+  if (hostname === "youtube.com" || hostname === "youtu.be") {
     const videoId = extractYouTubeId(cleanUrl)
     if (videoId) {
       return {
@@ -28,7 +38,7 @@ export function analyzeVideoUrl(url: string): VideoInfo {
   }
 
   // Vimeo detection
-  if (cleanUrl.includes("vimeo.com")) {
+  if (hostname === "vimeo.com") {
     const videoId = extractVimeoId(cleanUrl)
     if (videoId) {
       return {


### PR DESCRIPTION
Potential fix for [https://github.com/434media/next-434media/security/code-scanning/13](https://github.com/434media/next-434media/security/code-scanning/13)

To fix the problem, the code should parse the input URL using the standard `URL` class (available in modern JavaScript/TypeScript environments) and check the `hostname` property to determine if the URL is from YouTube or Vimeo. This avoids false positives from substring matches in other parts of the URL. The fix should be applied in the `analyzeVideoUrl` function in `app/lib/video-utils.ts`, specifically replacing the substring checks on lines 17 and 31 with proper hostname checks. If the codebase needs to support older environments, a polyfill or alternative parser may be required, but for most modern Node.js or browser environments, the built-in `URL` class suffices. No new external dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
