### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete URL substring sanitization

### DIFF
--- a/app/lib/event-parser.ts
+++ b/app/lib/event-parser.ts
@@ -60,11 +60,11 @@ export async function parseEventUrl(url: string): Promise<ParseResult> {
 
     let result: ParsedEventData
 
-    if (hostname.includes("meetup.com")) {
+    if (hostname === "meetup.com" || hostname.endsWith(".meetup.com")) {
       result = await parseMeetupEvent($, url)
-    } else if (hostname.includes("eventbrite.com")) {
+    } else if (hostname === "eventbrite.com" || hostname.endsWith(".eventbrite.com")) {
       result = await parseEventbriteEvent($, url)
-    } else if (hostname.includes("lu.ma")) {
+    } else if (hostname === "lu.ma" || hostname.endsWith(".lu.ma")) {
       result = await parseLumaEvent($, url)
     } else {
       throw new Error("Unsupported platform")


### PR DESCRIPTION
Potential fix for [https://github.com/434media/next-434media/security/code-scanning/11](https://github.com/434media/next-434media/security/code-scanning/11)

To fix the problem, replace the substring checks on lines 63, 65, and 67 with the same robust logic used in the allow-list check on line 20. Specifically, for each platform, check if the hostname is exactly equal to the allowed hostname or is a subdomain of it (i.e., ends with `.<allowed>`). This ensures that only legitimate hostnames are matched, and not arbitrary hostnames containing the allowed string. No new imports are needed, and the change is limited to the conditional logic in the `parseEventUrl` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
