### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/app/lib/content-analysis.ts
+++ b/app/lib/content-analysis.ts
@@ -138,13 +138,21 @@ export function extractEmbeddedMedia(html: string): EmbeddedMedia[] {
   // Extract videos (iframes and video elements)
   const iframes = tempDiv.querySelectorAll("iframe")
   iframes.forEach((iframe, index) => {
-    if (iframe.src.includes("youtube.com") || iframe.src.includes("vimeo.com")) {
-      media.push({
-        id: `video_${Date.now()}_${index}`,
-        type: "video",
-        url: iframe.src,
-        embedded_at: new Date().toISOString(),
-      })
+    try {
+      const urlObj = new URL(iframe.src);
+      const hostname = urlObj.hostname;
+      const isYouTube = hostname === "youtube.com" || hostname.endsWith(".youtube.com");
+      const isVimeo = hostname === "vimeo.com" || hostname.endsWith(".vimeo.com");
+      if (isYouTube || isVimeo) {
+        media.push({
+          id: `video_${Date.now()}_${index}`,
+          type: "video",
+          url: iframe.src,
+          embedded_at: new Date().toISOString(),
+        })
+      }
+    } catch (e) {
+      // Invalid URL, skip this iframe
     }
   })
 


### PR DESCRIPTION
Potential fix for [https://github.com/434media/next-434media/security/code-scanning/8](https://github.com/434media/next-434media/security/code-scanning/8)

To fix the problem, we should parse the `iframe.src` URL and check its `hostname` property, rather than using a substring match. This ensures that only iframes actually hosted on `youtube.com`, `vimeo.com`, or their subdomains are accepted. The best way is to use the standard `URL` constructor to parse the URL, and then check if the hostname is exactly `youtube.com`, `vimeo.com`, or ends with `.youtube.com` or `.vimeo.com` (to allow subdomains). This change should be made in the `extractEmbeddedMedia` function, specifically in the `iframes.forEach` block. We will also need to handle cases where the URL is invalid (e.g., catch exceptions from the `URL` constructor).

No new imports are needed, as the `URL` class is available in modern browsers and Node.js.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
