### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/app/lib/content-analysis.ts
+++ b/app/lib/content-analysis.ts
@@ -138,13 +138,24 @@ export function extractEmbeddedMedia(html: string): EmbeddedMedia[] {
   // Extract videos (iframes and video elements)
   const iframes = tempDiv.querySelectorAll("iframe")
   iframes.forEach((iframe, index) => {
-    if (iframe.src.includes("youtube.com") || iframe.src.includes("vimeo.com")) {
-      media.push({
-        id: `video_${Date.now()}_${index}`,
-        type: "video",
-        url: iframe.src,
-        embedded_at: new Date().toISOString(),
-      })
+    try {
+      const urlObj = new URL(iframe.src);
+      const allowedHosts = [
+        "youtube.com",
+        "www.youtube.com",
+        "vimeo.com",
+        "www.vimeo.com"
+      ];
+      if (allowedHosts.includes(urlObj.hostname)) {
+        media.push({
+          id: `video_${Date.now()}_${index}`,
+          type: "video",
+          url: iframe.src,
+          embedded_at: new Date().toISOString(),
+        })
+      }
+    } catch (e) {
+      // Invalid URL, skip
     }
   })
 


### PR DESCRIPTION
Potential fix for [https://github.com/434media/next-434media/security/code-scanning/7](https://github.com/434media/next-434media/security/code-scanning/7)

To fix the problem, we should parse the `iframe.src` URL and check the `hostname` property to ensure it matches exactly `youtube.com`, `vimeo.com`, or their known subdomains (e.g., `www.youtube.com`). This prevents attackers from bypassing the check by embedding the allowed domain as a substring elsewhere in the URL. The best way to do this in a browser environment is to use the built-in `URL` constructor, which safely parses the URL and exposes the `hostname` property. The fix should be applied in the `extractEmbeddedMedia` function, specifically in the `iframes.forEach` loop, replacing the substring check with a proper hostname check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
