### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/app/components/analytics/TrafficSourcesChart.tsx
+++ b/app/components/analytics/TrafficSourcesChart.tsx
@@ -22,8 +22,20 @@ interface SourceIconConfig {
   gradientTo: string
 }
 
+// Helper to extract host from a string, or return null if not a valid URL
+const getHost = (str: string): string | null => {
+  try {
+    // Add protocol if missing, to allow parsing bare domains
+    const url = str.match(/^https?:\/\//) ? new URL(str) : new URL("http://" + str);
+    return url.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+};
+
 const getSourceIconConfig = (source: string): SourceIconConfig => {
-  const lowerSource = source.toLowerCase()
+  const lowerSource = source.toLowerCase();
+  const host = getHost(source);
 
   // Main social platforms
   if (lowerSource.includes("facebook")) {
@@ -34,7 +46,11 @@ const getSourceIconConfig = (source: string): SourceIconConfig => {
       gradientTo: "to-[#1877F2]/5",
     }
   }
-  if (lowerSource.includes("twitter") || lowerSource.includes("x.com") || lowerSource === "x") {
+  if (
+    lowerSource.includes("twitter") ||
+    lowerSource === "x" ||
+    (host === "x.com" || host === "www.x.com")
+  ) {
     return {
       icon: <TwitterIcon />,
       color: "text-[#1DA1F2]",


### PR DESCRIPTION
Potential fix for [https://github.com/434media/next-434media/security/code-scanning/4](https://github.com/434media/next-434media/security/code-scanning/4)

To fix the problem, we should avoid using `includes("x.com")` on the entire source string. Instead, we should attempt to parse the source as a URL and check if the host is exactly `x.com` or a known subdomain (e.g., `www.x.com`). If parsing fails (because the source is not a URL), we can fall back to the existing checks (e.g., `lowerSource === "x"`). This approach ensures that only actual hosts matching `x.com` are classified as X, and not arbitrary strings containing `x.com`.

**Steps:**
- In `getSourceIconConfig`, before checking for `"x.com"`, attempt to parse `source` as a URL.
- If parsing succeeds, check if the host is exactly `x.com` or `www.x.com`.
- If parsing fails, fall back to the existing checks.
- Add a helper function to safely extract the host from a string.
- Add any necessary imports (e.g., `URL` is global in modern JS/TS, so no import needed).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
